### PR TITLE
chore: added CI / CD to publish in every new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - run: npm install
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - run: npm install
-
+      
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "lucid evolution provider for UTxORPC",
   "main": "./lib/index.js",
-  "module": "./lib/index.mjs",
   "exports": {
     ".": {
       "import": "./lib/index.mjs",
@@ -15,7 +14,6 @@
   "files": [
     "lib"
   ],
-  "type": "module",
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION
### Overview
This PR adds a GitHub Actions workflow to automatically publish the package to npm upon a new release.

### Changes
- Introduced a CI/CD workflow that runs on `ubuntu-latest` and installs dependencies before publishing the package.

### Secrets Requirement
The `NPM_TOKEN` secret must be added to the repository settings to enable secure authentication with npm for publishing.