### PR TITLE
feat: add functionality for using Credential in getUtxosWithUnit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@utxorpc/lucid-evolution-provider",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@utxorpc/lucid-evolution-provider",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@lucid-evolution/core-types": "^0.1.20",
+        "@lucid-evolution/core-types": "^0.1.21",
         "@lucid-evolution/core-utils": "^0.1.16",
-        "@lucid-evolution/lucid": "^0.3.41",
-        "@lucid-evolution/plutus": "^0.1.26",
-        "@lucid-evolution/provider": "^0.1.61",
-        "@lucid-evolution/sign_data": "^0.1.23",
-        "@lucid-evolution/utils": "^0.1.49",
-        "@lucid-evolution/wallet": "^0.1.52",
-        "@utxorpc/sdk": "^0.6.2",
-        "@utxorpc/spec": "^0.10.1"
+        "@lucid-evolution/lucid": "^0.4.3",
+        "@lucid-evolution/plutus": "^0.1.28",
+        "@lucid-evolution/provider": "^0.1.71",
+        "@lucid-evolution/sign_data": "^0.1.24",
+        "@lucid-evolution/utils": "^0.1.53",
+        "@lucid-evolution/wallet": "^0.1.59",
+        "@utxorpc/sdk": "^0.6.6",
+        "@utxorpc/spec": "^0.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",
@@ -26,7 +26,9 @@
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.9.0",
         "prettier": "^3.3.3",
+        "ts-node": "^10.9.2",
         "tsup": "^8.2.4",
+        "tsx": "^4.19.2",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.4.0"
       }
@@ -48,6 +50,78 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
       "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@connectrpc/connect": {
       "version": "1.4.0",
@@ -82,6 +156,40 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.4.2",
         "@connectrpc/connect": "1.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.71.7",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.71.7.tgz",
+      "integrity": "sha512-Ttw8OhbcP1x5cPgcX4VdnDSWrskVdUrf9bO3eDd++TTcQzEiYVu9GZJaSMvz6Yqzfzt+1tIKoKi2jp6dLdJ9dg==",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.5",
+        "multipasta": "^0.2.5"
+      },
+      "peerDependencies": {
+        "effect": "^3.11.10"
       }
     },
     "node_modules/@effect/schema": {
@@ -651,7 +759,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/bigint-utils/-/bigint-utils-1.0.0.tgz",
       "integrity": "sha512-OhZMHcdtH2hHKMlxWFHf71PmKHdoi9ARpjS9mUu0/cd8VWDDjT7VQoQwC5NN/68iyO4O5Dojrvrp9tjG5BDABA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@harmoniclabs/uint8array-utils": "^1.0.0"
       }
@@ -659,14 +766,12 @@
     "node_modules/@harmoniclabs/biguint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/biguint/-/biguint-1.0.0.tgz",
-      "integrity": "sha512-5DyCIBDL4W+7ffR1IJSbGrCG4xEYxAlFH5gCNF42qtyL5ltwZ92Ae1MyXpHM2TUPy7ocSTqlLUsOdy+SvqVVPw==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-5DyCIBDL4W+7ffR1IJSbGrCG4xEYxAlFH5gCNF42qtyL5ltwZ92Ae1MyXpHM2TUPy7ocSTqlLUsOdy+SvqVVPw=="
     },
     "node_modules/@harmoniclabs/bitstream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/bitstream/-/bitstream-1.0.0.tgz",
       "integrity": "sha512-Ed/I46IuCiytE5QiMmmUo9kPJcypM7OuUqoRaAXUALL5C6LKLpT6kYE1qeuhLkx2/WvkHT18jcOX6jhM/nmqoA==",
-      "license": "MIT",
       "dependencies": {
         "@harmoniclabs/uint8array-utils": "^1.0.0"
       }
@@ -675,56 +780,50 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/bytestring/-/bytestring-1.0.0.tgz",
       "integrity": "sha512-d5m10O0okKc6QNX0pSRriFTkk/kNMnMBGbo5X3kEZwKaXTI4tDVoTZBL7bwbYHwOEdSxWJjVtlO9xtB7ZrYZNg==",
-      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@harmoniclabs/uint8array-utils": "^1.0.0"
       }
     },
     "node_modules/@harmoniclabs/cbor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@harmoniclabs/cbor/-/cbor-1.3.0.tgz",
-      "integrity": "sha512-gzRqqcJL8sulc2/6iqRXZdWUCEeK3A+jwJ88sbVNzgk4IeMFQLSFg4Ck8ZBETu/W/q1zdknjNfJYyH1OxVriQA==",
-      "license": "Apache-2.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/cbor/-/cbor-1.5.0.tgz",
+      "integrity": "sha512-/TaUfh2POR88KJDtJvRokBgEu9QP+u3LSp92UenLizaFr9proKrb45jzC1IYeMvI9LWKo3zWtf6ea35TKq4ibQ==",
       "peer": true,
       "dependencies": {
         "@harmoniclabs/bytestring": "^1.0.0",
         "@harmoniclabs/obj-utils": "^1.0.0",
-        "@harmoniclabs/uint8array-utils": "^1.0.0"
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/HarmonicLabs"
       }
     },
     "node_modules/@harmoniclabs/crypto": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@harmoniclabs/crypto/-/crypto-0.2.4.tgz",
-      "integrity": "sha512-aVehpKFvgbzFn2qCoRHnrUHAB6XxU1YN61+2Tygo7T6oY3zubI0CI8Ydn2ELp2gidUaFzkICOKFZnAfq6Hxa3w==",
-      "license": "MIT",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/crypto/-/crypto-0.2.5.tgz",
+      "integrity": "sha512-t2saWMFWBx8tOHotiYTTfQKhPGpWT4AMLXxq3u0apShVXNV0vgL0gEgSMudBjES/wrKByCqa2xmU70gadz26hA==",
       "dependencies": {
         "@harmoniclabs/bitstream": "^1.0.0",
-        "@harmoniclabs/uint8array-utils": "^1.0.0"
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
       }
     },
     "node_modules/@harmoniclabs/obj-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/obj-utils/-/obj-utils-1.0.0.tgz",
       "integrity": "sha512-EO1bQBZAORrutcP+leP5YNDwNd/9TOE23VEvs3ktniXg6w0knUrLjUIl2Pkcbs/D1VQxqmsNpXho+vaMj00qxA==",
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@harmoniclabs/pair": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/pair/-/pair-1.0.0.tgz",
       "integrity": "sha512-D9OBowsUsy1LctHxWzd9AngTzoo5x3rBiJ0gu579t41Q23pb+VNx1euEfluUEiaYbgljcl1lb/4D1fFTZd1tRQ==",
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@harmoniclabs/plutus-data": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/plutus-data/-/plutus-data-1.2.4.tgz",
       "integrity": "sha512-cpr6AnJRultH6PJRDriewHEgNLQs2IGLampZrLjmK5shzTsHICD0yD0Zig9eKdcS7dmY6mlzvSpAJWPGeTxbCA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@harmoniclabs/biguint": "^1.0.0",
         "@harmoniclabs/crypto": "^0.2.4",
@@ -736,20 +835,17 @@
       }
     },
     "node_modules/@harmoniclabs/uint8array-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@harmoniclabs/uint8array-utils/-/uint8array-utils-1.0.0.tgz",
-      "integrity": "sha512-KNlgXCRGjmD3O+LYa3yTe3yKg8WY6C/bLs4Ywbjp7C9ORVxfppZDBd02LeK6jcIf800zadvJp+Bxk9qO+IcAQg==",
-      "license": "Apache-2.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/uint8array-utils/-/uint8array-utils-1.0.3.tgz",
+      "integrity": "sha512-MAOD0bGl3u4Ay98xRrNzwxu/UsI8oFsW/Gplry3KNUhmHhyeIH5NU+jtwtvlOYQH8eW5d6SdzqOTYWWQ7l0w+g=="
     },
     "node_modules/@harmoniclabs/uplc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@harmoniclabs/uplc/-/uplc-1.2.4.tgz",
-      "integrity": "sha512-Px6utj94cO/hQd9NJgVQI8zycsbgh3rAzDeLdZ1m52bo++EuU1GL+arWX3JYso3/3uNrnUFuizjrAIISwQe3Fg==",
-      "license": "Apache-2.0",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/uplc/-/uplc-1.4.0.tgz",
+      "integrity": "sha512-LV6E6sMN9y/xbsQiQnZ5SxFfGto3wmmeweA2KWB0Qs/Ga1gBQadtiec3W5T6Q4o1+2sPY6KeT4BH66Oh+WX2AQ==",
       "dependencies": {
         "@harmoniclabs/bigint-utils": "^1.0.0",
-        "@harmoniclabs/bitstream": "^1.0.0",
-        "@harmoniclabs/uint8array-utils": "^1.0.0"
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/HarmonicLabs"
@@ -913,35 +1009,42 @@
     "node_modules/@lucid-evolution/crc8": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@lucid-evolution/crc8/-/crc8-0.1.8.tgz",
-      "integrity": "sha512-88+/S6n+sPgxYtG05rvbJDVb8MoFGzckkR3p26uGrzngYzlJGfxBWIzNhVwfI2mgINPo2C5lkZW3GYnfY0MjuA==",
-      "license": "MIT"
+      "integrity": "sha512-88+/S6n+sPgxYtG05rvbJDVb8MoFGzckkR3p26uGrzngYzlJGfxBWIzNhVwfI2mgINPo2C5lkZW3GYnfY0MjuA=="
     },
     "node_modules/@lucid-evolution/lucid": {
-      "version": "0.3.41",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/lucid/-/lucid-0.3.41.tgz",
-      "integrity": "sha512-W4EfwVhRlrR+A/Z0fJ9dSbEIEJcBBG6nUValsW/I7G+IxdtkZY7+lWSsHa4mSJtkKchlOxsgRwyoYDP8aRYGsQ==",
-      "license": "MIT",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/lucid/-/lucid-0.4.19.tgz",
+      "integrity": "sha512-LlwC3yj9oojHoaxxCmTBeVyYLoegbhnvGnVAheM0otQuTa7z4IxHXIqxSopDgBTeG6psQGtJ0z2lkfgSxzPjOw==",
       "dependencies": {
-        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-2",
-        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-2",
+        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-3",
         "@effect/schema": "^0.66.14",
         "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
         "@lucid-evolution/core-types": "0.1.21",
         "@lucid-evolution/core-utils": "0.1.16",
-        "@lucid-evolution/plutus": "0.1.27",
-        "@lucid-evolution/provider": "0.1.64",
+        "@lucid-evolution/plutus": "0.1.28",
+        "@lucid-evolution/provider": "0.1.85",
         "@lucid-evolution/sign_data": "0.1.24",
-        "@lucid-evolution/uplc": "0.2.16",
-        "@lucid-evolution/utils": "0.1.49",
-        "@lucid-evolution/wallet": "0.1.55",
-        "effect": "^3.5.6"
+        "@lucid-evolution/uplc": "0.2.18",
+        "@lucid-evolution/utils": "0.1.63",
+        "@lucid-evolution/wallet": "0.1.69",
+        "effect": "^3.10.4"
       }
     },
+    "node_modules/@lucid-evolution/lucid/node_modules/@anastasia-labs/cardano-multiplatform-lib-browser": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-browser/-/cardano-multiplatform-lib-browser-6.0.2-3.tgz",
+      "integrity": "sha512-EP5Kr21xPtfEuCM3lR5tCIUQpMQ4Moisig8zD9BqUmBhQr/2ddxuE+MWhBF6tqH1AepzeXqRuTD1ozvdRn49Bw=="
+    },
+    "node_modules/@lucid-evolution/lucid/node_modules/@anastasia-labs/cardano-multiplatform-lib-nodejs": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-6.0.2-3.tgz",
+      "integrity": "sha512-Jy7QKahRQJgX6OFeuQvPXO0ejKfT9cQ8m3PFLBhbM04jjzFnaxlJJJ5+7qNHe3xdy40fMbMMe2SgAYPJ4gZ2Xw=="
+    },
     "node_modules/@lucid-evolution/plutus": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/plutus/-/plutus-0.1.27.tgz",
-      "integrity": "sha512-izBGkjIcWq3XK+pj9bCmTtRxjWM2brV0WTX4NkIFe2TgFMDVoqaYfkizIrOHwP2vIL8QbSPGShJQQwacl+i8Xg==",
-      "license": "MIT",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/plutus/-/plutus-0.1.28.tgz",
+      "integrity": "sha512-O8vOsed+U3dda32Y5iyvmnPUwuNR0K64RMow/fT+SUAcgDmTNVmXr63YG7lLrY165eC0DB/K6hsHMyqIF5DpBA==",
       "dependencies": {
         "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-2",
         "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-2",
@@ -951,41 +1054,35 @@
       }
     },
     "node_modules/@lucid-evolution/provider": {
-      "version": "0.1.64",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/provider/-/provider-0.1.64.tgz",
-      "integrity": "sha512-aulrpq1C2/G/hYUEfq+rJpLU/Gr+6ohu9Nki5xpwbDZA//BroR/Juxofi6bbUPz/R2i6Ysd1dCa3CO721qw4jw==",
-      "license": "MIT",
+      "version": "0.1.85",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/provider/-/provider-0.1.85.tgz",
+      "integrity": "sha512-a4t171fD2OO3SzFvlgjDDE9Npt47Kv6LYd0GkG3cjOM4ba5VZDnhXcfNn8lzidohm0HIFXLQ9Tytz9zDa8dFPw==",
       "dependencies": {
-        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-2",
-        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-2",
-        "@effect/platform": "^0.59.2",
+        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-3",
+        "@effect/platform": "^0.71.3",
         "@effect/schema": "^0.68.26",
         "@lucid-evolution/core-types": "0.1.21",
         "@lucid-evolution/core-utils": "0.1.16",
-        "@lucid-evolution/utils": "0.1.49",
-        "@lucid-evolution/wallet": "0.1.55",
-        "effect": "^3.5.6"
+        "@lucid-evolution/utils": "0.1.63",
+        "@lucid-evolution/wallet": "0.1.69",
+        "effect": "^3.11.7"
       }
     },
-    "node_modules/@lucid-evolution/provider/node_modules/@effect/platform": {
-      "version": "0.59.3",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.59.3.tgz",
-      "integrity": "sha512-DHR4Hl+hhTCzjs1ykRIyzwaala4JMtPVnReLea29hn+M3fKzloic7UpyCkTO7aJdFjthUtAKcW2mr2lDtuqlDA==",
-      "license": "MIT",
-      "dependencies": {
-        "find-my-way-ts": "^0.1.5",
-        "multipasta": "^0.2.2"
-      },
-      "peerDependencies": {
-        "@effect/schema": "^0.68.27",
-        "effect": "^3.5.7"
-      }
+    "node_modules/@lucid-evolution/provider/node_modules/@anastasia-labs/cardano-multiplatform-lib-browser": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-browser/-/cardano-multiplatform-lib-browser-6.0.2-3.tgz",
+      "integrity": "sha512-EP5Kr21xPtfEuCM3lR5tCIUQpMQ4Moisig8zD9BqUmBhQr/2ddxuE+MWhBF6tqH1AepzeXqRuTD1ozvdRn49Bw=="
+    },
+    "node_modules/@lucid-evolution/provider/node_modules/@anastasia-labs/cardano-multiplatform-lib-nodejs": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-6.0.2-3.tgz",
+      "integrity": "sha512-Jy7QKahRQJgX6OFeuQvPXO0ejKfT9cQ8m3PFLBhbM04jjzFnaxlJJJ5+7qNHe3xdy40fMbMMe2SgAYPJ4gZ2Xw=="
     },
     "node_modules/@lucid-evolution/provider/node_modules/@effect/schema": {
       "version": "0.68.27",
       "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.68.27.tgz",
       "integrity": "sha512-/rmIb+4QaQTecdTfeYSZtNikIV+BeIbYDl/hpgBTaS96en7pKNW5hcygFQhdocjKguIL7Y/be+oUrVafWV60ew==",
-      "license": "MIT",
       "dependencies": {
         "fast-check": "^3.20.0"
       },
@@ -1008,36 +1105,44 @@
       }
     },
     "node_modules/@lucid-evolution/uplc": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/uplc/-/uplc-0.2.16.tgz",
-      "integrity": "sha512-UqZZh5z5VQCq/OlvBkiewuYZYvO3xAzfC6+GyuMlvjtlgtEswL7GLDxLGqisqUPTX/gcuaQrd7eUBdrezz4fZQ=="
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/uplc/-/uplc-0.2.18.tgz",
+      "integrity": "sha512-TukA/1XnhrliAfwopPzX04t8j/7dfVygE9F55MypfibA+btZVOLJpe0VAFmr46HMcxecL/S63iOjuiRHNe+5bw=="
     },
     "node_modules/@lucid-evolution/utils": {
-      "version": "0.1.49",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/utils/-/utils-0.1.49.tgz",
-      "integrity": "sha512-G/P16DIW7x04f2wA9Kv+Ee+wAVR7KvZCbc0Pxt95SHjIgkFjkYAVLhyqbhFH4GylHfOZZ+l0s3uuiDvysoa0bg==",
-      "license": "MIT",
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/utils/-/utils-0.1.63.tgz",
+      "integrity": "sha512-oxdkIVo0O8/MufSN6d/EsnejDGvg4CNyGwdjzoLiq7MAgmSmz3Bwi2J6aezKCRMkPM12S4II0ZsNx0/EJmmKqA==",
       "dependencies": {
-        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-2",
-        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-2",
+        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-3",
         "@effect/schema": "^0.68.16",
         "@harmoniclabs/plutus-data": "^1.2.4",
         "@harmoniclabs/uplc": "^1.2.4",
         "@lucid-evolution/core-types": "0.1.21",
         "@lucid-evolution/core-utils": "0.1.16",
         "@lucid-evolution/crc8": "0.1.8",
-        "@lucid-evolution/plutus": "0.1.27",
-        "@lucid-evolution/uplc": "0.2.16",
+        "@lucid-evolution/plutus": "0.1.28",
+        "@lucid-evolution/uplc": "0.2.18",
         "bip39": "^3.1.0",
-        "cborg": "^4.2.0",
-        "effect": "^3.1.2"
+        "cbor-x": "^1.6.0",
+        "effect": "^3.10.4"
       }
+    },
+    "node_modules/@lucid-evolution/utils/node_modules/@anastasia-labs/cardano-multiplatform-lib-browser": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-browser/-/cardano-multiplatform-lib-browser-6.0.2-3.tgz",
+      "integrity": "sha512-EP5Kr21xPtfEuCM3lR5tCIUQpMQ4Moisig8zD9BqUmBhQr/2ddxuE+MWhBF6tqH1AepzeXqRuTD1ozvdRn49Bw=="
+    },
+    "node_modules/@lucid-evolution/utils/node_modules/@anastasia-labs/cardano-multiplatform-lib-nodejs": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-6.0.2-3.tgz",
+      "integrity": "sha512-Jy7QKahRQJgX6OFeuQvPXO0ejKfT9cQ8m3PFLBhbM04jjzFnaxlJJJ5+7qNHe3xdy40fMbMMe2SgAYPJ4gZ2Xw=="
     },
     "node_modules/@lucid-evolution/utils/node_modules/@effect/schema": {
       "version": "0.68.27",
       "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.68.27.tgz",
       "integrity": "sha512-/rmIb+4QaQTecdTfeYSZtNikIV+BeIbYDl/hpgBTaS96en7pKNW5hcygFQhdocjKguIL7Y/be+oUrVafWV60ew==",
-      "license": "MIT",
       "dependencies": {
         "fast-check": "^3.20.0"
       },
@@ -1046,25 +1151,33 @@
       }
     },
     "node_modules/@lucid-evolution/wallet": {
-      "version": "0.1.55",
-      "resolved": "https://registry.npmjs.org/@lucid-evolution/wallet/-/wallet-0.1.55.tgz",
-      "integrity": "sha512-mVrZEc1Vge3i30SwY4DZddWJS8HIiTs+JXuSX5QuGF/sNp0Rqi3LR9265y7fhmPiydfHvtnpWCkXB5gX1HcqxQ==",
-      "license": "MIT",
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@lucid-evolution/wallet/-/wallet-0.1.69.tgz",
+      "integrity": "sha512-CdqgfVmzJkRbj88676PDRj46fcWZhh6IuHSp0LH6On+brRCwAHXEXtHg8X07Cwlk6kYfm/1VxbPO9DIlt/FpFg==",
       "dependencies": {
-        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-2",
-        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-2",
+        "@anastasia-labs/cardano-multiplatform-lib-browser": "6.0.2-3",
+        "@anastasia-labs/cardano-multiplatform-lib-nodejs": "6.0.2-3",
         "@lucid-evolution/core-types": "0.1.21",
         "@lucid-evolution/core-utils": "0.1.16",
         "@lucid-evolution/sign_data": "0.1.24",
-        "@lucid-evolution/utils": "0.1.49",
+        "@lucid-evolution/utils": "0.1.63",
         "bip39": "^3.1.0"
       }
     },
+    "node_modules/@lucid-evolution/wallet/node_modules/@anastasia-labs/cardano-multiplatform-lib-browser": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-browser/-/cardano-multiplatform-lib-browser-6.0.2-3.tgz",
+      "integrity": "sha512-EP5Kr21xPtfEuCM3lR5tCIUQpMQ4Moisig8zD9BqUmBhQr/2ddxuE+MWhBF6tqH1AepzeXqRuTD1ozvdRn49Bw=="
+    },
+    "node_modules/@lucid-evolution/wallet/node_modules/@anastasia-labs/cardano-multiplatform-lib-nodejs": {
+      "version": "6.0.2-3",
+      "resolved": "https://registry.npmjs.org/@anastasia-labs/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-6.0.2-3.tgz",
+      "integrity": "sha512-Jy7QKahRQJgX6OFeuQvPXO0ejKfT9cQ8m3PFLBhbM04jjzFnaxlJJJ5+7qNHe3xdy40fMbMMe2SgAYPJ4gZ2Xw=="
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "license": "MIT",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1348,8 +1461,31 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.32.35",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
-      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
-      "license": "MIT"
+      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -1362,7 +1498,9 @@
       "version": "20.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
       "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1597,24 +1735,21 @@
       }
     },
     "node_modules/@utxorpc/sdk": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@utxorpc/sdk/-/sdk-0.6.2.tgz",
-      "integrity": "sha512-2duxfbH8B7DX3ync8U7BUYIi6lzerYwb8lMpW6Ax1fv3zqmJE39lGsBRVozJU1X3ITSB526ODkhgUo8DHRLvtQ==",
-      "license": "MIT",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@utxorpc/sdk/-/sdk-0.6.6.tgz",
+      "integrity": "sha512-rg984YH7i5SMEPQ23iR90uTgV6jjfiPtXaZJad99GI8YiLPsg7o1wSLnBayQMC79RlUDF8jvuIWjneMHM5AWVA==",
       "dependencies": {
         "@connectrpc/connect": "1.4",
         "@connectrpc/connect-node": "1.4",
         "@connectrpc/connect-web": "1.4",
-        "@types/node": "20.14.10",
-        "@utxorpc/spec": "0.10.1",
+        "@utxorpc/spec": "0.15.0",
         "buffer": "^6.0.3"
       }
     },
     "node_modules/@utxorpc/spec": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@utxorpc/spec/-/spec-0.10.1.tgz",
-      "integrity": "sha512-0INat5xSjkTeqKr+JO3SMQQ2PxcfZNUi5wJja/Fpnp68f52eTJf4X4QGy7tzqYzMsK/ZYhRr95J+WUeM6Vbmwg==",
-      "license": "MIT",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@utxorpc/spec/-/spec-0.15.0.tgz",
+      "integrity": "sha512-3JEblLJSBPLorExUSbuyL3giRGhpl6XxZkS/B+1hp4NzRK+rZdkDkeIwaEK/FgSNx/MVzXSRH7L1XVQRSTTlcA==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       },
@@ -1643,6 +1778,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1709,6 +1856,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1760,7 +1913,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
       "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
@@ -1849,13 +2001,33 @@
         "node": ">=6"
       }
     },
-    "node_modules/cborg": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.3.tgz",
-      "integrity": "sha512-XBFbEJ6WMfn9L7woc2t+EzOxF8vGqddoopKBbrhIvZBt2WIUgSlT8xLmM6Aq1xv8eWt4yOSjwxWjYeuHU3CpJA==",
-      "license": "Apache-2.0",
+    "node_modules/cbor-extract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
+      "integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
       "bin": {
-        "cborg": "lib/bin.js"
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.0"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.0.tgz",
+      "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.0"
       }
     },
     "node_modules/chalk": {
@@ -1960,6 +2132,12 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2000,6 +2178,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2008,10 +2204,12 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.8.3.tgz",
-      "integrity": "sha512-ZHTNRik0mJWK+g12/HHwsouOux0OE2v+qRD7zsEJLtZ1RJdrlxvCpSXdJ+KgOqJ4wigIToDSb5e5HG885uKs/w==",
-      "license": "MIT"
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.12.3.tgz",
+      "integrity": "sha512-3Z1eSq8TkbXcKHyakjFM+HHZ5ZQogD5uMM7RMb3aryE3GlfGKbqZ7DeSV111A0mHdI0NKDllorfSCfuYiLqz4A==",
+      "dependencies": {
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2265,9 +2463,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.22.0.tgz",
-      "integrity": "sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
       "funding": [
         {
           "type": "individual",
@@ -2278,7 +2476,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "pure-rand": "^6.1.0"
       },
@@ -2376,8 +2573,7 @@
     "node_modules/find-my-way-ts": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.5.tgz",
-      "integrity": "sha512-4GOTMrpGQVzsCH2ruUn2vmwzV/02zF4q+ybhCIrw/Rkt3L8KWcycdC6aJMctJzwN4fXD4SD5F/4B9Sksh5rE0A==",
-      "license": "MIT"
+      "integrity": "sha512-4GOTMrpGQVzsCH2ruUn2vmwzV/02zF4q+ybhCIrw/Rkt3L8KWcycdC6aJMctJzwN4fXD4SD5F/4B9Sksh5rE0A=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2473,6 +2669,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -2869,6 +3077,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2943,8 +3157,7 @@
     "node_modules/multipasta": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.5.tgz",
-      "integrity": "sha512-c8eMDb1WwZcE02WVjHoOmUVk7fnKU/RmUcosHACglrWAuPQsEJv+E8430sXj6jNc1jHw0zrS16aCjQh4BcEb4A==",
-      "license": "MIT"
+      "integrity": "sha512-c8eMDb1WwZcE02WVjHoOmUVk7fnKU/RmUcosHACglrWAuPQsEJv+E8430sXj6jNc1jHw0zrS16aCjQh4BcEb4A=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -2964,6 +3177,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3288,6 +3515,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/reusify": {
@@ -3698,6 +3934,49 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsup": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.0.tgz",
@@ -3758,6 +4037,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {
@@ -3827,7 +4125,9 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3838,6 +4138,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -3983,6 +4289,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "node --import tsx --test --experimental-fetch src/test/u5c.test.ts",
     "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf node_modules && rm -rf lib",
     "prepublish": "npm run build"
@@ -32,8 +33,8 @@
     "@lucid-evolution/sign_data": "^0.1.24",
     "@lucid-evolution/utils": "^0.1.53",
     "@lucid-evolution/wallet": "^0.1.59",
-    "@utxorpc/sdk": "^0.6.2",
-    "@utxorpc/spec": "^0.10.1"
+    "@utxorpc/sdk": "^0.6.6",
+    "@utxorpc/spec": "^0.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",
@@ -42,6 +43,7 @@
     "globals": "^15.9.0",
     "prettier": "^3.3.3",
     "tsup": "^8.2.4",
+    "tsx": "^4.19.2",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.4.0"
   }

--- a/src/test/u5c.test.ts
+++ b/src/test/u5c.test.ts
@@ -1,15 +1,71 @@
-import { UTxO } from "@lucid-evolution/core-types";
-import { U5C } from "../u5c";
+import {
+  Credential as LucidCredential,
+  UTxO,
+} from "@lucid-evolution/core-types";
+import { U5C } from "../u5c.js";
 import { describe, it } from "node:test";
 import assert from "assert";
 import fs from "fs";
+import {
+  addressFromHexOrBech32,
+  getAddressDetails,
+} from "@lucid-evolution/utils";
 
-const snapshots = JSON.parse(fs.readFileSync("u5cSnapshot.json", "utf-8"), (key, value) => {
-  if (typeof value === "string" && !isNaN(Number(value))) {
-    return BigInt(value);
+/**
+ * Transforms a UTxO to match the snapshot format:
+ * - Converts bech32 address to hex format
+ * - Moves 'lovelace' value to empty string key
+ * - Normalizes null/undefined values
+ */
+function transformUtxoToSnapshotFormat(utxo: UTxO): UTxO {
+  const transformedAssets = Object.entries(utxo.assets).reduce(
+    (acc, [key, value]) => {
+      const assetKey = key === "lovelace" ? "" : key;
+      acc[assetKey] = value;
+      return acc;
+    },
+    {} as { [key: string]: bigint },
+  );
+
+  if (!("lovelace" in utxo.assets)) {
+    transformedAssets[""] = BigInt(0);
   }
-  return value;
-});
+
+  return {
+    txHash: utxo.txHash,
+    outputIndex: utxo.outputIndex,
+    address: getAddressDetails(utxo.address).paymentCredential?.hash +
+      (getAddressDetails(utxo.address).stakeCredential?.hash || ""),
+    assets: transformedAssets,
+    datum: null,
+    datumHash: "",
+    scriptRef: null,
+  };
+}
+
+// Parse snapshots and convert numeric values to BigInt
+const snapshots = JSON.parse(
+  fs.readFileSync("src/test/u5cSnapshot.json", "utf-8"),
+  (key, value) => {
+    // Convert all numeric values in assets to BigInt
+    if (key === "assets" && typeof value === "object") {
+      const transformedAssets: { [key: string]: bigint } = {};
+      Object.entries(value).forEach(([k, v]) => {
+        transformedAssets[k] = typeof v === "number"
+          ? BigInt(v)
+          : BigInt(String(v));
+      });
+      return transformedAssets;
+    }
+    // Convert numeric strings to BigInt, except for datumHash
+    if (
+      key !== "datumHash" && typeof value === "string" && !isNaN(Number(value))
+    ) {
+      return BigInt(value);
+    }
+    return value;
+  },
+);
 
 describe("U5C Provider", () => {
   const provider = new U5C({
@@ -17,8 +73,7 @@ describe("U5C Provider", () => {
     headers: {
       "api-key": "",
     },
-  })
-
+  });
 
   const sampleAddress =
     "addr_test1qzdnkrpd5pqux2ctyrwj8rmzztcft92c79lj4k97dra74vhx8qcgyj7m7ge3sv5rrz4kvzkyfz9htrmttvuj4r5jau0qwl8umu";
@@ -26,40 +81,88 @@ describe("U5C Provider", () => {
     "5627f577d31b920c26cb69d07edf8b21327d4b485108805b9e68ace4436c61794e6174696f6e35";
   const sampleTx =
     "84a300d901028182582053d94c9a479f67a74620606d32c72a5e0f6b0388bd905dfc7f6c54604682f16f01018282581d60916c769efc6e2a3339594818a1d0c3998c29e3a6303d8711de8567591a004c4b4082581d60916c769efc6e2a3339594818a1d0c3998c29e3a6303d8711de8567591b00000002536e1b66021a0002990da100d9010281825820526fa19e3694cda4f3c0d2fb2d2bb8768925eccc49a89d5f12b1972644ac7698584086e3f1505249d44b56ba83e8119bb05080c5c117002ae25c124b0ba2dcc91cf1b338e715b451d8024d80da54cdcea4be07625d778bb7ab7b2803162aafc6e60ff5f6";
-  const sampleSubmittedtx = 
+  const sampleSubmittedtx =
     "53d94c9a479f67a74620606d32c72a5e0f6b0388bd905dfc7f6c54604682f16f";
-  const sampleOutRef = 
-    [
-      {
-        txHash:
-          "40a3296355d4a7ee4654b52685a9b07958ab4a0dd3a1c6aec80bfb8393306c9e",
-        outputIndex: 1,
-      },
-    ];
+  const sampleOutRef = [
+    {
+      txHash:
+        "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
+      outputIndex: 1,
+    },
+  ];
+
+  
 
   describe("getUtxoByUnit", () => {
     it("should fetch UTxO by unit", async () => {
-      const utxos: UTxO = await provider.getUtxoByUnit(sampleAsset);
-      assert.deepStrictEqual(utxos, snapshots.getUtxoByUnit.result);
+      const utxo: UTxO = await provider.getUtxoByUnit(sampleAsset);
+      assert.deepStrictEqual(transformUtxoToSnapshotFormat(utxo), snapshots.getUtxoByUnit.result);
     });
   });
 
-  describe("getUtxosWithUnit", () => {
-    it("should fetch UTxOs with asset", async () => {
+  describe("getUtxosWithUnit from address", () => {
+    it("should fetch UTxOs with asset from address", async () => {
       const utxos: UTxO[] = await provider.getUtxosWithUnit(
         sampleAddress,
         sampleAsset
       );
-      assert.deepStrictEqual(utxos, snapshots.getUtxosWithUnit.result);
+      const transformedUtxos = utxos.map(utxo=>transformUtxoToSnapshotFormat(utxo));
+      assert.deepStrictEqual(
+        transformedUtxos,
+        snapshots.getUtxosWithUnit.result,
+      );
+    });
+  });
+
+  describe("getUtxosWithUnit from Credential", () => {
+    it("should fetch UTxOs with unit from a Credential", async () => {
+      const addressDetails = getAddressDetails(sampleAddress);
+      const paymentCred = addressDetails.paymentCredential;
+      const utxos: UTxO[] = await provider.getUtxosWithUnit(
+        paymentCred!,
+        sampleAsset,
+      );
+      const transformedUtxos = utxos.map(utxo=>transformUtxoToSnapshotFormat(utxo));
+      assert.deepStrictEqual(
+        transformedUtxos,
+        snapshots.getUtxosWithUnit.result,
+      );
     });
   });
 
   describe("getUtxos", () => {
     it("should fetch UTxOs without asset", async () => {
       const utxos: UTxO[] = await provider.getUtxos(sampleAddress);
-      assert.deepStrictEqual(utxos, snapshots.getUtxosWithUnit.result);
+      const transformedUtxos = utxos.map(utxo=>transformUtxoToSnapshotFormat(utxo));
+      console.log(transformedUtxos);
+      // Verify that the transformation preserves the essential UTxO properties
+      transformedUtxos.forEach(utxo => {
+        // Original UTxO should exist with same txHash and outputIndex
+        const originalUtxo = utxos.find(u => u.txHash === utxo.txHash && u.outputIndex === utxo.outputIndex);
+        assert.ok(originalUtxo, "Each transformed UTxO should have a corresponding original UTxO");
+        
+        // Verify lovelace value is preserved
+        const originalLovelace = originalUtxo.assets.lovelace || BigInt(0);
+        assert.strictEqual(utxo.assets[""], originalLovelace, "Lovelace value should be preserved");
+        
+        // Verify other assets are preserved
+        Object.entries(originalUtxo.assets).forEach(([key, value]) => {
+          if (key !== "lovelace") {
+            assert.strictEqual(utxo.assets[key], value, `Asset ${key} value should be preserved`);
+          }
+        });
+      });
     });
   });
+
+  describe("getUtxosByOutRef", () => {
+    it("should fetch UTxOs by OutRef", async () => {
+      const utxos: UTxO[] = await provider.getUtxosByOutRef(sampleOutRef);
+      const transformedUtxos = utxos.map(utxo=>transformUtxoToSnapshotFormat(utxo));
+      assert.deepStrictEqual(transformedUtxos, snapshots.getUtxosByOutRef.result);
+    });
+  });
+  
 
   describe("getProtocolParameters", () => {
     it("should fetch protocol parameters", async () => {
@@ -82,10 +185,5 @@ describe("U5C Provider", () => {
     });
   });
 
-  describe("getUtxosByOutRef", () => {
-    it("should fetch UTxOs by OutRef", async () => {
-      const utxos: UTxO[] = await provider.getUtxosByOutRef(sampleOutRef);
-      assert.deepStrictEqual(utxos, snapshots.getUtxosByOutRef.result);
-    });
-  });
+  
 });

--- a/src/test/u5cSnapshot.json
+++ b/src/test/u5cSnapshot.json
@@ -1,18 +1,17 @@
 {
     "getUtxoByUnit": {
       "result": {
-        "txHash": "66e27d8854cd50c23bf04e0daa9ee52b0385687dfe97f9382cf9d1ab2a94439e",
+        "txHash": "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
         "outputIndex": 1,
-        "address": "009b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+        "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
         "assets": {
-          "047e0f912c4260fe66ae271e5ae494dcd5f79635bbbb1386be195f4e414c4c45594b41545a3030303133": 1,
+          "": 17439700601,
           "0d0ab97d0286339b065dd8078d8f330c32a2047e18a4c78ea55f2f9855534443": 1000,
           "5627f577d31b920c26cb69d07edf8b21327d4b485108805b9e68ace4436c61794e6174696f6e35": 1,
           "69e0f064986469479685e5cc6b5caa8f853129f443fa974086edcbc25468654d616e6472696c6c7a436f6d70616e696f6e733233": 1,
           "8524270246030f17732bd36d23ef309de9395709f06a6a5f3b29e48c486f736b79": 15,
           "8b05e87a51c1d4a0fa888d2bb14dbc25e8c343ea379a171b63aa84a0434e4354": 10000000,
-          "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000,
-          "": 0
+          "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000
         },
         "datumHash": "",
         "datum": null,
@@ -22,54 +21,100 @@
     "getUtxosWithUnit": {
       "result": [
         {
-          "txHash": "66e27d8854cd50c23bf04e0daa9ee52b0385687dfe97f9382cf9d1ab2a94439e",
+          "txHash": "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
           "outputIndex": 1,
-          "address": "009b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
           "assets": {
-            "047e0f912c4260fe66ae271e5ae494dcd5f79635bbbb1386be195f4e414c4c45594b41545a3030303133": 1,
+            "": 17439700601,
             "0d0ab97d0286339b065dd8078d8f330c32a2047e18a4c78ea55f2f9855534443": 1000,
             "5627f577d31b920c26cb69d07edf8b21327d4b485108805b9e68ace4436c61794e6174696f6e35": 1,
             "69e0f064986469479685e5cc6b5caa8f853129f443fa974086edcbc25468654d616e6472696c6c7a436f6d70616e696f6e733233": 1,
             "8524270246030f17732bd36d23ef309de9395709f06a6a5f3b29e48c486f736b79": 15,
             "8b05e87a51c1d4a0fa888d2bb14dbc25e8c343ea379a171b63aa84a0434e4354": 10000000,
-            "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000,
-            "": 0
+            "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000
           },
-          "datumHash": "",
           "datum": null,
-          "scriptRef": null
-        },
-        {
-          "txHash": "e49ec6d2558c0fedd59bb8483d6073b713b793b9dbc9cd40f9b0ebcaf90831ce",
-          "outputIndex": 0,
-          "address": "009b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
-          "assets": { "": 0 },
           "datumHash": "",
-          "datum": null,
-          "scriptRef": null
-        },
-        {
-          "txHash": "a875578776b0eacdf753e9d6a0d184726a2eb8349d92350457442dd89f20e02a",
-          "outputIndex": 0,
-          "address": "009b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
-          "assets": { "": 0 },
-          "datumHash": "",
-          "datum": null,
-          "scriptRef": null
-        },
-        {
-          "txHash": "e97f2e036960e8f32eddb69308fd7a01ba25701d1257f85801d3952bcbceaf8b",
-          "outputIndex": 1,
-          "address": "009b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
-          "assets": { "": 0 },
-          "datumHash": "",
-          "datum": null,
           "scriptRef": null
         }
       ]
     },
     "getUtxos": {
-      "result": "Same as getUtxosWithUnit"
+      "result": [
+        {
+          "txHash": "e97f2e036960e8f32eddb69308fd7a01ba25701d1257f85801d3952bcbceaf8b",
+          "outputIndex": 1,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 500000000
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        },
+        {
+          "txHash": "e49ec6d2558c0fedd59bb8483d6073b713b793b9dbc9cd40f9b0ebcaf90831ce",
+          "outputIndex": 0,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 99820527
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        },
+        {
+          "txHash": "a875578776b0eacdf753e9d6a0d184726a2eb8349d92350457442dd89f20e02a",
+          "outputIndex": 0,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 5000000
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        },
+        {
+          "txHash": "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
+          "outputIndex": 0,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 122000000
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        },
+        {
+          "txHash": "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
+          "outputIndex": 1,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 17439700601,
+            "0d0ab97d0286339b065dd8078d8f330c32a2047e18a4c78ea55f2f9855534443": 1000,
+            "5627f577d31b920c26cb69d07edf8b21327d4b485108805b9e68ace4436c61794e6174696f6e35": 1,
+            "69e0f064986469479685e5cc6b5caa8f853129f443fa974086edcbc25468654d616e6472696c6c7a436f6d70616e696f6e733233": 1,
+            "8524270246030f17732bd36d23ef309de9395709f06a6a5f3b29e48c486f736b79": 15,
+            "8b05e87a51c1d4a0fa888d2bb14dbc25e8c343ea379a171b63aa84a0434e4354": 10000000,
+            "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        },
+        {
+          "txHash": "f9bc28c16ecf980303c0c3dde13cf9a7d3489f054715e293599493006d639a06",
+          "outputIndex": 0,
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 1180940,
+            "047e0f912c4260fe66ae271e5ae494dcd5f79635bbbb1386be195f4e414c4c45594b41545a3030303133": 1
+          },
+          "datum": null,
+          "datumHash": "",
+          "scriptRef": null
+        }
+      ]
     },
     "getProtocolParameters": {
       "result": {
@@ -272,10 +317,18 @@
     "getUtxosByOutRef": {
       "result": [
         {
-          "txHash": "40a3296355d4a7ee4654b52685a9b07958ab4a0dd3a1c6aec80bfb8393306c9e",
+          "txHash": "f8c9671ad59cdf2bd63b8e9878e5dee20abde3ec5f9fe13f43956e0ca570907d",
           "outputIndex": 1,
-          "address": "60916c769efc6e2a3339594818a1d0c3998c29e3a6303d8711de856759",
-          "assets": { "": 0 },
+          "address": "9b3b0c2da041c32b0b20dd238f6212f0959558f17f2ad8be68fbeab2e63830824bdbf23318328318ab660ac4488b758f6b5b392a8e92ef1e",
+          "assets": {
+            "": 17439700601,
+            "0d0ab97d0286339b065dd8078d8f330c32a2047e18a4c78ea55f2f9855534443": 1000,
+            "5627f577d31b920c26cb69d07edf8b21327d4b485108805b9e68ace4436c61794e6174696f6e35": 1,
+            "69e0f064986469479685e5cc6b5caa8f853129f443fa974086edcbc25468654d616e6472696c6c7a436f6d70616e696f6e733233": 1,
+            "8524270246030f17732bd36d23ef309de9395709f06a6a5f3b29e48c486f736b79": 15,
+            "8b05e87a51c1d4a0fa888d2bb14dbc25e8c343ea379a171b63aa84a0434e4354": 10000000,
+            "b8e7a467c263e37c86b3696112e2736caad9c32b113b612fe35daf8a4352415348": 800000
+          },
           "datumHash": "",
           "datum": null,
           "scriptRef": null

--- a/src/u5c.ts
+++ b/src/u5c.ts
@@ -1,8 +1,8 @@
 import { Address } from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
 import {
-  Credential as LucidCredential,
   Address as LucidAddress,
   Assets,
+  Credential as LucidCredential,
   Datum,
   DatumHash,
   Delegation,
@@ -18,6 +18,7 @@ import {
   UTxO,
 } from "@lucid-evolution/core-types";
 import { fromHex, toHex } from "@lucid-evolution/core-utils";
+import { CML } from "@lucid-evolution/lucid";
 
 import { CardanoQueryClient, CardanoSubmitClient } from "@utxorpc/sdk";
 import type * as spec from "@utxorpc/spec";
@@ -47,8 +48,9 @@ export class U5C implements Provider {
 
   evaluateTx(
     tx: Transaction,
-    additionalUTxOs?: UTxO[]
+    additionalUTxOs?: UTxO[],
   ): Promise<EvalRedeemer[]> {
+    // TODO: implement evaluateTx
     throw new Error("Method not implemented.");
   }
 
@@ -62,13 +64,14 @@ export class U5C implements Provider {
   }
 
   async getUtxos(
-    addressOrCredential: LucidAddress | LucidCredential
+    addressOrCredential: LucidAddress | LucidCredential,
   ): Promise<UTxO[]> {
     if (typeof addressOrCredential === "string") {
       const address = Address.from_bech32(addressOrCredential);
       const addressBytes = address.to_raw_bytes();
-      const utxoSearchResult =
-        await this.queryClient.searchUtxosByAddress(addressBytes);
+      const utxoSearchResult = await this.queryClient.searchUtxosByAddress(
+        addressBytes,
+      );
       return utxoSearchResult.map((result: any) => this._mapToUTxO(result));
     } else if (
       addressOrCredential &&
@@ -78,11 +81,11 @@ export class U5C implements Provider {
     ) {
       let credentialBytes: Uint8Array;
       credentialBytes = fromHex(addressOrCredential.hash);
-      
-      const utxoSearchResultPayment =
-        await this.queryClient.searchUtxosByPaymentPart(credentialBytes);
-      const utxoSearchResultDelegation =
-        await this.queryClient.searchUtxosByDelegationPart(credentialBytes);
+
+      const utxoSearchResultPayment = await this.queryClient
+        .searchUtxosByPaymentPart(credentialBytes);
+      const utxoSearchResultDelegation = await this.queryClient
+        .searchUtxosByDelegationPart(credentialBytes);
       const combinedResults = [
         ...utxoSearchResultPayment,
         ...utxoSearchResultDelegation,
@@ -107,22 +110,59 @@ export class U5C implements Provider {
 
   async getUtxosWithUnit(
     addressOrCredential: LucidAddress | LucidCredential,
-    unit: Unit
+    unit: Unit,
   ): Promise<UTxO[]> {
+    const unitBytes = fromHex(unit);
+
     if (typeof addressOrCredential === "string") {
       const address = Address.from_bech32(addressOrCredential);
       const addressBytes = address.to_raw_bytes();
-      const unitBytes = fromHex(unit);
-      const utxoSearchResult =
-        await this.queryClient.searchUtxosByAddressWithAsset(
+      const utxoSearchResult = await this.queryClient
+        .searchUtxosByAddressWithAsset(
           addressBytes,
           undefined,
-          unitBytes
+          unitBytes,
         );
       return utxoSearchResult.map((result: any) => this._mapToUTxO(result));
-    } else if (addressOrCredential instanceof Credential) {
-      // TODO: Implement Credential handling
-      throw new Error("Credential handling is not yet implemented");
+    } else if (
+      addressOrCredential &&
+      (addressOrCredential.type === "Key" ||
+        addressOrCredential.type === "Script") &&
+      typeof addressOrCredential.hash === "string"
+    ) {
+      let credentialBytes: Uint8Array;
+      credentialBytes = fromHex(addressOrCredential.hash);
+
+      const utxoSearchResultPayment = await this.queryClient
+        .searchUtxosByPaymentPartWithAsset(
+          credentialBytes,
+          undefined,
+          unitBytes,
+        );
+      const utxoSearchResultDelegation = await this.queryClient
+        .searchUtxosByDelegationPartWithAsset(
+          credentialBytes,
+          undefined,
+          unitBytes,
+        );
+      const combinedResults = [
+        ...utxoSearchResultPayment,
+        ...utxoSearchResultDelegation,
+      ];
+
+      const uniqueUtxos = new Map<string, any>();
+
+      for (const utxo of combinedResults) {
+        const key = `${utxo.txoRef.hash}-${utxo.txoRef.index}`;
+        if (!uniqueUtxos.has(key)) {
+          uniqueUtxos.set(key, utxo);
+        }
+      }
+
+      return Array.from(uniqueUtxos.values()).map((result: any) =>
+        this._mapToUTxO(result)
+      );
+      // throw new Error("Credential handling is not yet implemented");
     } else {
       throw new Error("Invalid address or credential type");
     }
@@ -133,7 +173,7 @@ export class U5C implements Provider {
 
     const utxoSearchResult = await this.queryClient.searchUtxosByAsset(
       undefined,
-      unitBytes
+      unitBytes,
     );
 
     if (utxoSearchResult.length === 0) {
@@ -158,21 +198,27 @@ export class U5C implements Provider {
       };
     });
 
-    const utxoSearchResult =
-      await this.queryClient.readUtxosByOutputRef(references);
+    const utxoSearchResult = await this.queryClient.readUtxosByOutputRef(
+      references,
+    );
 
     return utxoSearchResult.map((result: any) => this._mapToUTxO(result));
   }
 
   async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+    // TODO: implement getDelegation
     throw new Error("Method not implemented.");
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
+    // TODO: implement getDatum
     throw new Error("Method not implemented.");
   }
 
-  async awaitTx(txHash: TxHash, checkInterval: number = 1000): Promise<boolean> {
+  async awaitTx(
+    txHash: TxHash,
+    checkInterval: number = 1000,
+  ): Promise<boolean> {
     const updates = this.submitClient.waitForTx(fromHex(txHash));
 
     for await (const stage of updates) {
@@ -283,7 +329,7 @@ export class U5C implements Provider {
 
   // @TODO: use the rpc response and map to core types instead of hardcoded values
   private _rpcPParamsToCorePParams(
-    rpcPParams: spec.cardano.PParams
+    rpcPParams: spec.cardano.PParams,
   ): ProtocolParameters {
     return {
       minFeeA: Number(44),

--- a/src/u5c.ts
+++ b/src/u5c.ts
@@ -162,7 +162,6 @@ export class U5C implements Provider {
       return Array.from(uniqueUtxos.values()).map((result: any) =>
         this._mapToUTxO(result)
       );
-      // throw new Error("Credential handling is not yet implemented");
     } else {
       throw new Error("Invalid address or credential type");
     }


### PR DESCRIPTION
Changes also involved upgrading versions for utxorp/sdk and utxorpc/spec to:
"@utxorpc/sdk": "^0.6.6",
"@utxorpc/spec": "^0.15.0"
 These new versions allow using searchUtxosByPaymentPartWithAsset and searchUtxosByDelegationPartWithAsset.

I also made some updates to the snapshot used for the tests and added an npm test script.  I am not sure if that was the intended way to use it but I was unable to run the tests previously.